### PR TITLE
feat: swagger로 회원가입 테스트 #5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// Swagger UI 의존성
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/sparta/homework_login/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/homework_login/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.sparta.homework_login.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "회원가입 API", version = "1.0", description = "Swagger를 활용한 회원가입 API 문서"),
+        security = @SecurityRequirement(name = "Authorization") // Swagger에서 JWT 인증 적용
+)
+@SecurityScheme(
+        name = "Authorization",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class SwaggerConfig {
+
+}

--- a/src/main/java/com/sparta/homework_login/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/homework_login/config/WebSecurityConfig.java
@@ -101,6 +101,7 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll() // '/auth/'로 시작하는 요청 모두 접근 허가
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );

--- a/src/main/java/com/sparta/homework_login/controller/UserController.java
+++ b/src/main/java/com/sparta/homework_login/controller/UserController.java
@@ -1,8 +1,15 @@
 package com.sparta.homework_login.controller;
 
 import com.sparta.homework_login.dto.request.SignUpRequestDto;
+import com.sparta.homework_login.dto.response.ErrorResponseDto;
 import com.sparta.homework_login.dto.response.SignUpResponseDto;
 import com.sparta.homework_login.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "회원 관리 API", description = "회원가입 및 사용자 관리 API")
 public class UserController {
 
     private final UserService userService;
@@ -31,6 +39,29 @@ public class UserController {
      * @return 회원가입 처리 결과
      * @since 2025-01-17
      */
+    @Operation(summary = "회원가입", description = "회원 정보를 입력받아 회원가입을 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "회원가입 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 데이터",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponseDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 사용자입니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponseDto.class)
+                    )
+            )
+    })
     @PostMapping("/auth/users")
     public ResponseEntity<SignUpResponseDto> signUp(
             @RequestBody @Valid SignUpRequestDto requestDto

--- a/src/main/java/com/sparta/homework_login/dto/request/SignInRequestDto.java
+++ b/src/main/java/com/sparta/homework_login/dto/request/SignInRequestDto.java
@@ -1,5 +1,6 @@
 package com.sparta.homework_login.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,9 +16,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignInRequestDto {
 
+    @Schema(example = "Hong Gil Dong", description = "사용자 이름")
     @NotBlank(message = "이름을 입력해주세요")
     private String username;
 
+    @Schema(example = "1q2w3e4r#", description = "비밀번호")
     @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
 }

--- a/src/main/java/com/sparta/homework_login/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/sparta/homework_login/dto/request/SignUpRequestDto.java
@@ -1,6 +1,7 @@
 package com.sparta.homework_login.dto.request;
 
 import com.sparta.homework_login.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -17,13 +18,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignUpRequestDto {
 
+    @Schema(example = "Hong Gil Dong", description = "사용자 이름")
     @NotBlank(message = "이름을 입력해주세요")
     private String username;
 
+    @Schema(example = "1q2w3e4r#", description = "비밀번호")
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
             message = "비밀번호는 [8 ~ 20]글자 이내이며, [영문 + 숫자 + 특수문자]를 최소 1글자씩 포함해야 합니다.")
     private String password;
 
+    @Schema(example = "동에 번쩍", description = "닉네임")
     @NotBlank(message = "닉네임을 입력해주세요")
     private String nickname;
 

--- a/src/main/java/com/sparta/homework_login/dto/response/ErrorResponseDto.java
+++ b/src/main/java/com/sparta/homework_login/dto/response/ErrorResponseDto.java
@@ -2,6 +2,7 @@ package com.sparta.homework_login.dto.response;
 
 import com.sparta.homework_login.enums.ErrorCode;
 import com.sparta.homework_login.exception.BusinessException;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -14,9 +15,16 @@ import java.time.format.DateTimeFormatter;
  */
 @Data
 public class ErrorResponseDto {
+    @Schema(example = "2025-01-18 19:53:48", description = "에러 발생 시간 (yyyy-MM-dd HH:mm:ss)")
     private String date;
+
+    @Schema(example = "400", description = "HTTP 상태 코드")
     private int state;
+
+    @Schema(example = "잘못된 요청입니다.", description = "에러 메시지")
     private String message;
+
+    @Schema(example = "http://localhost:8080/api/..", description = "요청한 URL")
     private String url;
 
     public ErrorResponseDto(BusinessException ex, String requestUrl) {

--- a/src/main/java/com/sparta/homework_login/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/sparta/homework_login/dto/response/SignInResponseDto.java
@@ -1,5 +1,6 @@
 package com.sparta.homework_login.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,5 +14,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SignInResponseDto {
 
+    @Schema(example = "Bearer ...", description = "발급된 토큰")
     private final String bearerToken;
 }

--- a/src/main/java/com/sparta/homework_login/dto/response/SignUpResponseDto.java
+++ b/src/main/java/com/sparta/homework_login/dto/response/SignUpResponseDto.java
@@ -1,6 +1,7 @@
 package com.sparta.homework_login.dto.response;
 
 import com.sparta.homework_login.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,8 +22,13 @@ import java.util.List;
 @NoArgsConstructor
 public class SignUpResponseDto {
 
+    @Schema(example = "Hong Gil Dong", description = "회원 이릅")
     private String userName;
+
+    @Schema(example = "동에 번쩍", description = "닉네임")
     private String nickname;
+
+    @Schema(example = "[\"ROLE_USER\"]", description = "권한")
     private List<AuthorDto> authorities;
 
     /**

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -1,0 +1,16 @@
+# Swagger
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  api-docs:
+    groups:
+      enabled: true
+  swagger-ui:
+    operations-sorter: alpha # alpha(알파벳 오름차순), method(HTTP메소드순)
+    tags-sorter: alpha # 태그 정렬 기준
+    path: /swagger # html 문서 접속 경로
+    disable-swagger-default-url: true
+    doc-expansion: none # tag, operation 펼치는 방식
+  paths-to-match:
+    - /**
+  show-login-endpoint: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,5 +3,6 @@ spring:
     name: HOMEWORK_LOGIN
   profiles:
     include:
+      - swagger
       - jwt
       - dev


### PR DESCRIPTION
## 🔘 담당 파트
- 회원가입 & 로그인 화면 추가

## 🔎 작업 상세 내용
- Swagger UI를 활용하여 화면 구성
- build.gradle swagger 의존성 추가
- SwaggerConfig 추가
- favicon.ico 추가
- dto와 controller에 문서에 필요한 태그들 추가
- 로그인 항목 추가를 위해 application-swagger.yml추가
- 로그인 문서는 추후에 다시 시도..

## 🔧 앞으로의 과제
- 회원 가입 테스트 코드 작성
- 로그인 테스트 코드 작성
- 배포
- 코드 개선 & 정리 및 주석
- README 작성

## ➕ 이슈 링크
- #5